### PR TITLE
Fix various issues with sunshine formula

### DIFF
--- a/Formula/s/sunshine.rb
+++ b/Formula/s/sunshine.rb
@@ -5,12 +5,13 @@ class Sunshine < Formula
   homepage "https://app.lizardbyte.dev/Sunshine"
   url "https://github.com/LizardByte/Sunshine.git",
     tag: "v0.23.1"
-  version "0.23.1"
   license all_of: ["GPL-3.0-only"]
-  head "https://github.com/LizardByte/Sunshine.git", branch: "nightly"
+  head "https://github.com/LizardByte/Sunshine.git", branch: "master"
 
   depends_on "boost" => :build
   depends_on "cmake" => :build
+  depends_on "doxygen" => :build
+  depends_on "graphviz" => :build # for `dot`
   depends_on "node" => :build
   depends_on "pkg-config" => :build
   depends_on "curl"
@@ -20,8 +21,14 @@ class Sunshine < Formula
 
   def install
     ENV["BRANCH"] = "master"
-    ENV["BUILD_VERSION"] = "v0.23.1"
-    ENV["COMMIT"] = "8b21db64fb8e8ffb9c24a412dbc66b7410699211"
+    ENV["BUILD_VERSION"] = "v#{version}"
+    if build.head?
+      # For a HEAD build, the `version` field will be something like "HEAD-59ff5dc". This works
+      # fine itself as a value for BUILD_VERSION. Sticking a "v" prefix in front of this value
+      # would look ugly, so we'll remove the prefix.
+      ENV["BUILD_VERSION"] = ENV["BUILD_VERSION"][1..]
+    end
+    ENV["COMMIT"] = `git rev-parse HEAD`.strip
 
     args = %W[
       -DBUILD_WERROR=ON


### PR DESCRIPTION
## Description

- Fix the name of the development branch used for HEAD builds. It's
  `master` now, not `nightly`.

- Add missing build depenendies: `doxygen` and `graphviz` (the latter of
  which is required because it provides the `dot` command).

- Remove redundantly-specified version field, because the tag name
  already contains the version.

- Set `ENV["BUILD_VERSION"]` to the actual version being built, rather
  than hardcoding a specific value.

- Set `ENV["COMMIT"]` to the actual commit hash being built, rather than
  hardcoding a specific value.


### Screenshot

N/A


### Issues Fixed or Closed

N/A


## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [ ] My code follows the style guidelines of this project
  - I could not locate any style guidelines relevant to brew formulae for this project. However,
    the pull request passes `brew audit`.
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
